### PR TITLE
Ensure valid menu selections

### DIFF
--- a/calendarManager.ps1
+++ b/calendarManager.ps1
@@ -7,20 +7,26 @@ function User-Login {
 }
 
 function Set-Action {
-    # Ask if they want to do
-    Write-Host ""
-    Write-Host "Choose an action:"
-    Write-Host "1. Modify default permissions"
-    Write-Host "2. Update permissions for a specific user"
-    Write-Host "3. Remove a custom permission for a specific user"
-    
-    $PermissionActionChoice = Read-Host -Prompt "Enter the number corresponding to the action you want to perform"
+    do {
+        # Ask if they want to do
+        Write-Host ""
+        Write-Host "Choose an action:"
+        Write-Host "1. Modify default permissions"
+        Write-Host "2. Update permissions for a specific user"
+        Write-Host "3. Remove a custom permission for a specific user"
 
-    $PermissionAction = switch ($PermissionActionChoice) {
-    "1" { "default" }
-    "2" { "specific" }
-    "3" { "remove" }
-    }
+        $PermissionActionChoice = Read-Host -Prompt "Enter the number corresponding to the action you want to perform"
+
+        $PermissionAction = switch ($PermissionActionChoice) {
+            "1" { "default" }
+            "2" { "specific" }
+            "3" { "remove" }
+            default {
+                Write-Host "Invalid selection. Please enter 1, 2, or 3." -ForegroundColor Red
+                $null
+            }
+        }
+    } while (-not $PermissionAction)
 
     return $PermissionAction
 }
@@ -71,36 +77,42 @@ do {
 
     # If Permissions is modified what should we do
     if ($PermissionAction -eq 'specific' -or $PermissionAction -eq 'default'){
-        # List permission levels
-        Write-Host ""
-        Write-Host "Please choose the permission level you'd like to set:"
-        Write-Host "1. Owner"
-        Write-Host "2. PublishingEditor"
-        Write-Host "3. Editor"
-        Write-Host "4. PublishingAuthor"
-        Write-Host "5. Author"
-        Write-Host "6. NonEditingAuthor"
-        Write-Host "7. Reviewer"
-        Write-Host "8. Contributor"
-        Write-Host "9. AvailabilityOnly"
-        Write-Host "10. LimitedDetails"
+        do {
+            # List permission levels
+            Write-Host ""
+            Write-Host "Please choose the permission level you'd like to set:"
+            Write-Host "1. Owner"
+            Write-Host "2. PublishingEditor"
+            Write-Host "3. Editor"
+            Write-Host "4. PublishingAuthor"
+            Write-Host "5. Author"
+            Write-Host "6. NonEditingAuthor"
+            Write-Host "7. Reviewer"
+            Write-Host "8. Contributor"
+            Write-Host "9. AvailabilityOnly"
+            Write-Host "10. LimitedDetails"
 
-        # Prompt user to choose permission level
-        $PermissionLevel = Read-Host -Prompt "Enter the number corresponding to the permission level"
+            # Prompt user to choose permission level
+            $PermissionLevel = Read-Host -Prompt "Enter the number corresponding to the permission level"
 
-        # Convert the number to a permission level string
-        $PermissionLevelText = switch ($PermissionLevel) {
-            "1" { "Owner" }
-            "2" { "PublishingEditor" }
-            "3" { "Editor" }
-            "4" { "PublishingAuthor" }
-            "5" { "Author" }
-            "6" { "NonEditingAuthor" }
-            "7" { "Reviewer" }
-            "8" { "Contributor" }
-            "9" { "AvailabilityOnly" }
-            "10" { "LimitedDetails" }
-        }
+            # Convert the number to a permission level string
+            $PermissionLevelText = switch ($PermissionLevel) {
+                "1" { "Owner" }
+                "2" { "PublishingEditor" }
+                "3" { "Editor" }
+                "4" { "PublishingAuthor" }
+                "5" { "Author" }
+                "6" { "NonEditingAuthor" }
+                "7" { "Reviewer" }
+                "8" { "Contributor" }
+                "9" { "AvailabilityOnly" }
+                "10" { "LimitedDetails" }
+                default {
+                    Write-Host "Invalid selection. Please enter a number from 1 to 10." -ForegroundColor Red
+                    $null
+                }
+            }
+        } while (-not $PermissionLevelText)
     }
 
 


### PR DESCRIPTION
## Summary
- prevent invalid menu selections in `Set-Action`
- require valid numeric permission level choice

## Testing
- `pwsh -NoLogo -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseInput((Get-Content -Path 'calendarManager.ps1' -Raw), [ref]$null, [ref]$null) | Out-Null; Write-Host 'Parse completed'"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_689b53439894832cba3a2b76d5f35008