### PR TITLE
Refactor permission selection

### DIFF
--- a/calendarManager.ps1
+++ b/calendarManager.ps1
@@ -17,16 +17,16 @@ function Set-Action {
     $PermissionActionChoice = Read-Host -Prompt "Enter the number corresponding to the action you want to perform"
 
     $PermissionAction = switch ($PermissionActionChoice) {
-    "1" { "default" }
-    "2" { "specific" }
-    "3" { "remove" }
+        "1" { "default" }
+        "2" { "specific" }
+        "3" { "remove" }
     }
 
     return $PermissionAction
 }
 
 function Get-PermissionLevel {
-    [ordered]$permissionLevels = @{
+    $permissionLevels = [ordered]@{
         "1"  = "Owner"
         "2"  = "PublishingEditor"
         "3"  = "Editor"
@@ -42,11 +42,11 @@ function Get-PermissionLevel {
     do {
         Write-Host ""
         Write-Host "Please choose the permission level you'd like to set:"
-        foreach ($entry in $permissionLevels.GetEnumerator()) {
-            Write-Host "$($entry.Key). $($entry.Value)"
+        foreach ($k in $permissionLevels.Keys) {
+            Write-Host "$k. $($permissionLevels[$k])"
         }
         $selection = Read-Host -Prompt "Enter the number corresponding to the permission level"
-    } until ($permissionLevels.ContainsKey($selection))
+    } until ($permissionLevels.Contains($selection))
 
     return $permissionLevels[$selection]
 }
@@ -68,15 +68,16 @@ function Add-Or-Update-Permission {
     )
 
     # Check if the permission exists
-        $existingPermission = Get-MailboxFolderPermission -Identity "${Email}:\Calendar" -User $User -ErrorAction SilentlyContinue
+    $existingPermission = Get-MailboxFolderPermission -Identity "${Email}:\Calendar" -User $User -ErrorAction SilentlyContinue
 
-        if ($null -eq $ExistingPermission) {
-            # Add the permission if it doesn't exist
-            Add-MailboxFolderPermission -Identity "${Email}:\Calendar" -User $User -AccessRights $Access
-        } else {
-            # Update the existing permission
-            Set-MailboxFolderPermission -Identity "${Email}:\Calendar" -User $User -AccessRights $Access
-        }
+    if ($null -eq $existingPermission) {
+        # Add the permission if it doesn't exist
+        Add-MailboxFolderPermission -Identity "${Email}:\Calendar" -User $User -AccessRights $Access
+    }
+    else {
+        # Update the existing permission
+        Set-MailboxFolderPermission -Identity "${Email}:\Calendar" -User $User -AccessRights $Access
+    }
 }
 
 User-Login
@@ -96,7 +97,7 @@ do {
     }
 
     # If Permissions is modified what should we do
-    if ($PermissionAction -eq 'specific' -or $PermissionAction -eq 'default'){
+    if ($PermissionAction -eq 'specific' -or $PermissionAction -eq 'default') {
         $PermissionLevelText = Get-PermissionLevel
     }
 

--- a/calendarManager.ps1
+++ b/calendarManager.ps1
@@ -25,6 +25,32 @@ function Set-Action {
     return $PermissionAction
 }
 
+function Get-PermissionLevel {
+    [ordered]$permissionLevels = @{
+        "1"  = "Owner"
+        "2"  = "PublishingEditor"
+        "3"  = "Editor"
+        "4"  = "PublishingAuthor"
+        "5"  = "Author"
+        "6"  = "NonEditingAuthor"
+        "7"  = "Reviewer"
+        "8"  = "Contributor"
+        "9"  = "AvailabilityOnly"
+        "10" = "LimitedDetails"
+    }
+
+    do {
+        Write-Host ""
+        Write-Host "Please choose the permission level you'd like to set:"
+        foreach ($entry in $permissionLevels.GetEnumerator()) {
+            Write-Host "$($entry.Key). $($entry.Value)"
+        }
+        $selection = Read-Host -Prompt "Enter the number corresponding to the permission level"
+    } until ($permissionLevels.ContainsKey($selection))
+
+    return $permissionLevels[$selection]
+}
+
 function Get-Permissions {
     param(
         [string]$CalendarOwner
@@ -71,36 +97,7 @@ do {
 
     # If Permissions is modified what should we do
     if ($PermissionAction -eq 'specific' -or $PermissionAction -eq 'default'){
-        # List permission levels
-        Write-Host ""
-        Write-Host "Please choose the permission level you'd like to set:"
-        Write-Host "1. Owner"
-        Write-Host "2. PublishingEditor"
-        Write-Host "3. Editor"
-        Write-Host "4. PublishingAuthor"
-        Write-Host "5. Author"
-        Write-Host "6. NonEditingAuthor"
-        Write-Host "7. Reviewer"
-        Write-Host "8. Contributor"
-        Write-Host "9. AvailabilityOnly"
-        Write-Host "10. LimitedDetails"
-
-        # Prompt user to choose permission level
-        $PermissionLevel = Read-Host -Prompt "Enter the number corresponding to the permission level"
-
-        # Convert the number to a permission level string
-        $PermissionLevelText = switch ($PermissionLevel) {
-            "1" { "Owner" }
-            "2" { "PublishingEditor" }
-            "3" { "Editor" }
-            "4" { "PublishingAuthor" }
-            "5" { "Author" }
-            "6" { "NonEditingAuthor" }
-            "7" { "Reviewer" }
-            "8" { "Contributor" }
-            "9" { "AvailabilityOnly" }
-            "10" { "LimitedDetails" }
-        }
+        $PermissionLevelText = Get-PermissionLevel
     }
 
 


### PR DESCRIPTION
## Summary
- add `Get-PermissionLevel` function to map numeric choices to access rights
- replace inline permission selection with reusable function

## Testing
- `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('calendarManager.ps1',[ref]$null,[ref]$null)"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y powershell` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689b53551ac0832c9ee3fb8232450682